### PR TITLE
move pyserial requirement to a requirements.txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Usage
 
 ### Linux
 
+    pip install -r requirements.txt
     python wattsup.py -p /dev/ttyUSBX -i
     python wattsup.py --help
 
@@ -18,6 +19,7 @@ Usage
 
 Install the http://www.ftdichip.com/Drivers/VCP.htm drivers. Restart.
 
+    port install py-serial
     python wattsup.py -p /dev/tty.usbserial-X -i
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyserial

--- a/wattsup.py
+++ b/wattsup.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python3
 
+import serial
+
 import sys
-try:
-    import serial
-except ImportError:
-    print('Need serial package.')
-    print('sudo port install py-serial')
-    sys.exit(1)
 import os
 import datetime, time
 import argparse


### PR DESCRIPTION
As a linux user, I accidentally installed the serial package which nobody uses instead of the correct `pyserial` package. 
a requirements.txt file can prevent that from happening. 